### PR TITLE
GM API

### DIFF
--- a/lib/stockastic.ex
+++ b/lib/stockastic.ex
@@ -53,7 +53,7 @@ defmodule Stockastic do
 
   @spec url(client :: Client.t, path :: binary) :: binary
   defp url(_client = %Client{endpoint: endpoint}, path) do
-    endpoint <> path
+    Path.join([endpoint, path])
   end
 
   @spec build_qs([{atom, binary}]) :: binary

--- a/lib/stockastic/client.ex
+++ b/lib/stockastic/client.ex
@@ -1,5 +1,5 @@
 defmodule Stockastic.Client do
-  defstruct auth: nil, endpoint: "https://api.stockfighter.io/ob/api/"
+  defstruct auth: nil, endpoint: "https://api.stockfighter.io"
 
   @type auth :: %{access_token: binary}
   @type t :: %__MODULE__{auth: auth, endpoint: binary}

--- a/lib/stockastic/client.ex
+++ b/lib/stockastic/client.ex
@@ -12,11 +12,6 @@ defmodule Stockastic.Client do
 
   @spec new(auth, binary) :: t
   def new(auth, endpoint) do
-    endpoint = if String.ends_with?(endpoint, "/") do
-      endpoint
-    else
-      endpoint <> "/"
-    end
     %__MODULE__{auth: auth, endpoint: endpoint}
   end
 end

--- a/lib/stockastic/levels.ex
+++ b/lib/stockastic/levels.ex
@@ -1,0 +1,99 @@
+defmodule Stockastic.Levels do
+  import Stockastic
+
+  @moduledoc """
+  This module exposes gm API, as described here:
+  https://discuss.starfighters.io/t/the-gm-api-how-to-start-stop-restart-resume-trading-levels-automagically/143
+  """
+
+  @doc """
+  Starts a level by its name
+
+  ## Example
+
+      Stockastic.Levels.start "first_steps", client
+
+  """
+  @spec start(binary, Client.t) :: Stockastic.response
+  def start(level, client) do
+    post "gm/levels/#{level}", client
+  end
+
+  @doc """
+  NOT YET IMPLEMENTED ON SERVER, as of this writing
+
+  List accessible levels, with their level ids
+
+  ## Example
+
+      Stockastic.Levels.list client
+
+  """
+  @spec list(Client.t) :: Stockastic.response
+  def list(client) do
+    get "gm/levels", client
+  end
+
+  defmodule Instances do
+
+    @moduledoc """
+    This module implements level instances manipulation API, as specified on
+    https://discuss.starfighters.io/t/the-gm-api-how-to-start-stop-restart-resume-trading
+    """
+
+    @doc """
+    Get the status (open/closed, tradingDay, etc) of the target level instance
+
+    ## Example
+
+        Stockastic.Levels.Instances.status 117261, client
+
+    """
+    @spec status(integer, Client.t) :: Stockastic.response
+    def status(instance_id, client) do
+      get "gm/instances/#{instance_id}", client
+    end
+
+    @doc """
+    Restart given level instance
+
+    ## Example
+
+        Stockastic.Levels.Instances.restart 117261, client
+
+    """
+    @spec restart(integer, Client.t) :: Stockastic.response
+    def restart(instance_id, client) do
+      post "gm/instances/#{instance_id}/restart", client
+    end
+
+    @doc """
+    Stop given level instance
+
+    ## Example
+
+        Stockastic.Levels.Instances.restart 117261, client
+
+    """
+    @spec stop(integer, Client.t) :: Stockastic.response
+    def stop(instance_id, client) do
+      post "gm/instances/#{instance_id}/stop", client
+    end
+
+    @doc """
+    Resume given level instance
+    (helpful to remind you trading account id or venues and tickers for the current puzzle)
+
+    ## Example
+
+        Stockastic.Levels.Instances.restart 117261, client
+
+    """
+    @spec resume(integer, Client.t) :: Stockastic.response
+    def resume(instance_id, client) do
+      post "gm/instances/#{instance_id}/resume", client
+    end
+
+  end
+
+end

--- a/lib/stockastic/orders.ex
+++ b/lib/stockastic/orders.ex
@@ -23,7 +23,7 @@ defmodule Stockastic.Orders do
   """
   @spec list(binary, binary, Client.t) :: Stockastic.response
   def list(venue, account, client) do
-    get "venues/#{venue}/accounts/#{account}/orders", client
+    get "ob/api/venues/#{venue}/accounts/#{account}/orders", client
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule Stockastic.Orders do
   """
   @spec list_for_stock(binary, binary, binary, Client.t) :: Stockastic.response
   def list_for_stock(venue, account, stock, client) do
-    get "venues/#{venue}/accounts/#{account}/stocks/#{stock}/orders", client
+    get "ob/api/venues/#{venue}/accounts/#{account}/stocks/#{stock}/orders", client
   end
 
   @doc """
@@ -51,7 +51,7 @@ defmodule Stockastic.Orders do
   """
   @spec find(binary, binary, integer, Client.t) :: Stockastic.response
   def find(venue, stock, id, client) do
-    get "venues/#{venue}/stocks/#{stock}/orders/#{id}", client
+    get "ob/api/venues/#{venue}/stocks/#{stock}/orders/#{id}", client
   end
 
   @doc """
@@ -65,7 +65,7 @@ defmodule Stockastic.Orders do
   """
   @spec cancel(binary, binary, integer, Client.t) :: Stockastic.response
   def cancel(venue, stock, id, client) do
-    delete "venues/#{venue}/stocks/#{stock}/orders/#{id}", client
+    delete "ob/api/venues/#{venue}/stocks/#{stock}/orders/#{id}", client
   end
 
   @doc """
@@ -90,6 +90,6 @@ defmodule Stockastic.Orders do
   """
   @spec place_order(binary, binary, order, Client.t) :: Stockastic.response
   def place_order(venue, stock, body, client) do
-    post "venues/#{venue}/stocks/#{stock}/orders", client, body
+    post "ob/api/venues/#{venue}/stocks/#{stock}/orders", client, body
   end
 end

--- a/lib/stockastic/stocks.ex
+++ b/lib/stockastic/stocks.ex
@@ -13,7 +13,7 @@ defmodule Stockastic.Stocks do
   """
   @spec list(binary, Client.t) :: Stockastic.response
   def list(venue, client) do
-    get "venues/#{venue}/stocks", client
+    get "ob/api/venues/#{venue}/stocks", client
   end
 
   @doc """
@@ -27,7 +27,7 @@ defmodule Stockastic.Stocks do
   """
   @spec orderbook(binary, binary, Client.t) :: Stockastic.response
   def orderbook(venue, stock, client) do
-    get "venues/#{venue}/stocks/#{stock}", client
+    get "ob/api/venues/#{venue}/stocks/#{stock}", client
   end
 
   @doc """
@@ -41,6 +41,6 @@ defmodule Stockastic.Stocks do
   """
   @spec get_quote(binary, binary, Client.t) :: Stockastic.response
   def get_quote(venue, stock, client) do
-    get "venues/#{venue}/stocks/#{stock}/quote", client
+    get "ob/api/venues/#{venue}/stocks/#{stock}/quote", client
   end
 end

--- a/lib/stockastic/venues.ex
+++ b/lib/stockastic/venues.ex
@@ -13,6 +13,6 @@ defmodule Stockastic.Venues do
   """
   @spec heartbeat(binary, Client.t) :: Stockastic.response
   def heartbeat(venue, client) do
-    get "venues/#{venue}/heartbeat", client
+    get "ob/api/venues/#{venue}/heartbeat", client
   end
 end


### PR DESCRIPTION
I've found [this API specification](https://discuss.starfighters.io/t/the-gm-api-how-to-start-stop-restart-resume-trading-levels-automagically/143) and thought that it would be cool to expose those in the Elixir client.

Please also note usage of `Path.join` — no need to keep in mind those nasty trailing slashes anymore!

Of course some clever usage of parametric `use Stockastic.Client prefix: "ob/api"` can save use from duplicating those path prefixes here and there — but I don't want to spoil party for all other forkers/contributors by starting a huge refactoring on the early stage.
